### PR TITLE
Incorrect type $Mail.ProfileNumber

### DIFF
--- a/Private/Convert-HexToBinary.ps1
+++ b/Private/Convert-HexToBinary.ps1
@@ -1,0 +1,10 @@
+function Convert-HexToBinary {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)] [string] $Hex
+    )
+    $return = for ($i = 0; $i -lt $Hex.Length ; $i += 2) {
+        [Byte]::Parse($Hex.Substring($i, 2), [System.Globalization.NumberStyles]::HexNumber)
+    }
+    Write-Output $return -NoEnumerate
+}

--- a/Public/Start-OutlookProfile.ps1
+++ b/Public/Start-OutlookProfile.ps1
@@ -228,8 +228,7 @@ function Start-OutlookProfile {
                             }
                         }
 
-                        [int] $PrimaryProfile = $Mail.ProfileNumber
-                        [byte[]] $ByteArray = @($PrimaryProfile, 0, 0, 0)
+                        [byte[]] $ByteArray = Convert-HexToBinary -Hex $Mail.ProfileNumber
                         $SubValue = "$($Mail.ProfilePath)\9375CFF0413111d3B88A00104B2A6676"
                         #Try {
                         #    Write-Color "[i] ", "Setting default profile ", $SubValue, ' in ', "{ED475418-B0D6-11D2-8C3B-00104B2A6676}", ' with ', $ByteArray -Color Blue, White, Yellow, White, Green, White, Yellow


### PR DESCRIPTION
If ProfileNumber 10 or greater, error :

`[int] $PrimaryProfile = $Mail.ProfileNumber

                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
CategoryInfo : InvalidArgument: (:) [], RuntimeException
FullyQualifiedErrorId : InvalidCastFromStringToInteger`